### PR TITLE
Change the handling of the werr argument of the format function

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ error.debug(true)
 - `mode:boolean`: `true` to enable the debug mode, or `false` to disable it.
 
 
-## err = error.new( message [, wrap [, level [, traceback]]] )
+## err = error.new( message [, werr [, level [, traceback]]] )
 
 creates a new error object.
 
@@ -65,7 +65,7 @@ print(err)
 
 - `message:error.message|any`: a message value.  
   - if it is not `error.message`, create `error.message` with that message.
-- `wrap:error`: `nil` or other error objects to be included in the new error object.
+- `werr:error`: `nil` or other error objects to be included in the new error object.
 - `level:integer`: specifies how to get the error position. (default: `1`)
 - `traceback:boolean`: get the stack traceback and keep it in the error object. (default: `false`)
 
@@ -91,7 +91,7 @@ print(err.op) -- equivalent to err.message.op
 - `op:string`: the `op` property of the `error.message` object.
 
 
-## err = error.toerror( message [, wrap [, level [, traceback]]] )
+## err = error.toerror( message [, werr [, level [, traceback]]] )
 
 equivalent to the `error.new` function, but if the `message` is an `error` object, it will be returned.
 
@@ -105,9 +105,9 @@ print(err == error.toerror('my error2')) -- false
 ```
 
 
-## err = error.format( fmt [, ..., [, wrap [, level [, traceback]]]] )
+## err = error.format( fmt [, ..., [, werr [, level [, traceback]]]] )
 
-equivalent to the `error.new` function, but the `message` argument is formatted with `snprintf`.
+equivalent to the `error.new` function, but the `message` argument is formatted with `snprintf`. And, if the `werr` is not an `error` object, it will be concatenated with the formatted message.
 
 the format specifiers are the same as `snprintf` of the C standard library except for the following specifiers.
 
@@ -348,7 +348,7 @@ print(error.type.get('my_error_type')) -- nil
 - `ok:boolean`: `true` on success.
 
 
-## err = errt:new( [message [, wrap [, level [, traceback]]]] )
+## err = errt:new( [message [, werr [, level [, traceback]]]] )
 
 equivalent to the `error.new` function except message argument can be set to `nil`.  
 it also sets the `error.type` object to the `error` object.
@@ -601,7 +601,7 @@ load the lua-error module.
 
 ## int lua_error_new(lua_State *L, int msgidx)
 
-create a new error that equivalent to `error.new(message [, wrap [, level [, traceback]]])` function.
+create a new error that equivalent to `error.new(message [, werr [, level [, traceback]]])` function.
 
 
 ## int lua_error_new_type(lua_State *L, int nameidx)
@@ -611,7 +611,7 @@ create a new error type that equivalent to `error.type.new(name [, code [, messa
 
 ## int lua_error_new_typed_error(lua_State *L, int typeidx)
 
-create a new typed error that equivalent to `<myerr>:new([msg [, wrap [, level [, traceback]]]])` method.
+create a new typed error that equivalent to `<myerr>:new([msg [, werr [, level [, traceback]]]])` method.
 
 
 ## int lua_error_registry_get(lua_State *L, const char *name)

--- a/src/error.c
+++ b/src/error.c
@@ -438,6 +438,15 @@ static int format_lua(lua_State *L)
         lua_pushlstring(L, head, cur - head);
     }
 
+    // if err argument is passed but not an error object, convert it to string
+    // and concat to error message
+    if (nextarg < narg && !lua_isnoneornil(L, nextarg + 1) &&
+        !lauxh_isuserdataof(L, nextarg + 1, LUA_ERROR_MT)) {
+        push_format_string(L, ": %s", 's', nextarg + 1);
+        lua_pushnil(L);
+        lua_replace(L, nextarg + 1);
+    }
+
     // concat all strings
     lua_concat(L, lua_gettop(L) - narg);
     // replace format string with concatenated string
@@ -448,6 +457,7 @@ static int format_lua(lua_State *L)
         lua_insert(L, 2);
     }
     lua_settop(L, top);
+
     return lua_error_new(L, 1);
 }
 

--- a/src/lua_error.h
+++ b/src/lua_error.h
@@ -26,6 +26,7 @@
 #include <ctype.h>
 #include <lauxhlib.h>
 #include <lua.h>
+#include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/test/format_test.lua
+++ b/test/format_test.lua
@@ -12,6 +12,12 @@ function testcase.format()
     assert.re_match(v, 'hello (\\(nil\\)|0x[0-9a-f]+)')
     assert.equal(error.unwrap(v), hello_error)
 
+    -- test that the error object argument is concatenated into a message
+    -- string if it is not an error object
+    v = error.format('hello', 'error format')
+    assert.match(v, 'hello: error format')
+    assert.is_nil(error.unwrap(v))
+
     -- test that integer type: d, i, o, u, x, X
     v = error.format('%+d %-5i %05o %u %#x %#X %ld %d %d', 42, 42, 42, 42, 42,
                      42, 42, true, false)


### PR DESCRIPTION
if the werr is not an error object, it will be concatenated with the formatted message.