### PR TITLE
Refactor lua_error.h to include lauxlib.h directly

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -24,7 +24,7 @@
 #include <math.h>
 #include <stdint.h>
 // lua
-#include <lauxhlib.h>
+#include "lauxhlib.h"
 
 static inline const char *typename(lua_State *L, int type)
 {

--- a/src/lua_error.h
+++ b/src/lua_error.h
@@ -28,7 +28,7 @@
 #include <string.h>
 #include <unistd.h>
 // lua
-#include <lauxhlib.h>
+#include <lauxlib.h>
 #include <lua.h>
 
 #define LUA_ERROR_API            static inline


### PR DESCRIPTION
This pull request makes minor changes to the way Lua headers are included in the codebase to improve consistency and correctness.

Header include updates:

* Changed the include of `lauxhlib.h` from angle brackets to quotes in `src/check.c`, making it a local include.
* Replaced the non-standard `lauxhlib.h` with the standard Lua header `lauxlib.h` in `src/lua_error.h`.