### PR TITLE
Add lauxhlib include path to check module

### DIFF
--- a/rockspecs/error-scm-1.rockspec
+++ b/rockspecs/error-scm-1.rockspec
@@ -18,7 +18,7 @@ dependencies = {
     "string-format-all >= 0.2.0",
 }
 build_dependencies = {
-    "luarocks-build-hooks >= 0.7.0",
+    "luarocks-build-hooks >= 0.8.0",
 }
 build = {
     type = "hooks",
@@ -44,7 +44,12 @@ build = {
         ["error.message"] = "lib/message.lua",
         ["error.tostring"] = "lib/tostring.lua",
         ["error.type"] = "lib/type.lua",
-        ["error.check"] = "src/check.c",
+        ["error.check"] = {
+            sources = "src/check.c",
+            incdirs = {
+                "$(DEP_LAUXHLIB_INCDIR)",
+            },
+        },
         ["error.where"] = "src/where.c",
     },
     install = {


### PR DESCRIPTION
This pull request updates the build configuration for the `error` module, mainly by updating a build dependency and improving how the native extension `error.check` is defined in the rockspec. The most important changes are:

Dependency updates:

* Updated the `luarocks-build-hooks` build dependency requirement from version `>= 0.7.0` to `>= 0.8.0` in `rockspecs/error-scm-1.rockspec` to ensure compatibility with newer build features.

Build configuration improvements:

* Changed the definition of the `error.check` native module in `rockspecs/error-scm-1.rockspec` to specify the source file and include directories explicitly, allowing for better integration with external dependencies such as `lauxhlib`.